### PR TITLE
Bug fix: Old attribute value keep reset back when new attribute is created

### DIFF
--- a/functions/get-shopify-products.ts
+++ b/functions/get-shopify-products.ts
@@ -76,7 +76,6 @@ function formatCost(cost: string): number {
 async function searchShopifyProduct(searchTerm: string, env: Env, logger: Logger): Promise<ShopifyProduct | null> {
   const baseUrl = normalizeUrl(env.SHOPIFY_STORE_URL);
   logger.info('Searching Shopify product', { searchTerm });
-  await logger.flush();
 
   const startTime = Date.now();
   const response = await fetch(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,6 +82,8 @@ function App() {
         !existingVariantSkus.includes(mapping.variant.sku)
       );
 
+      console.log('Filtered mappings for import:', filteredMappings);
+
       if (filteredMappings.length === 0) {
         throw new Error('No new variants to import');
       }
@@ -127,7 +129,7 @@ function App() {
         if (attributesPayload.length === 0) {
           throw new Error('No configurable attributes found');
         }
-        console.log('filteredMappings', filteredMappings)
+
         const response = await fetch('/create-configurable-product', {
           method: 'POST',
           headers: {

--- a/src/components/AttributeMapping.tsx
+++ b/src/components/AttributeMapping.tsx
@@ -505,7 +505,7 @@ const AttributeMapping: React.FC<AttributeMappingProps> = ({
                                                         value: opt.value
                                                     }))}
                                                     value={mapping.mappedValue as string}
-                                                    onChange={(value: string, label: string, newOptions?: Option[]) => handleValueChange(shopifyAttr, value, newOptions)} placeholder="Select Value"
+                                                    onChange={(value: string, _: string, newOptions?: Option[]) => handleValueChange(shopifyAttr, value, newOptions)} placeholder="Select Value"
                                                     attributeCode={mapping.mappedTo}
                                                     allowCreate={true}
                                                 />

--- a/src/components/AttributeMapping.tsx
+++ b/src/components/AttributeMapping.tsx
@@ -355,8 +355,22 @@ const AttributeMapping: React.FC<AttributeMappingProps> = ({
     };
 
     const handleValueChange = (shopifyAttr: string, value: string | string[]) => {
+
+        // Get the selected attribute
+        const attributeCode = mappings[shopifyAttr].mappedTo;
+        const attribute = attributes.find(attr => attr.attribute_code === attributeCode);
+
+        // Find the label for the selected value from Magento options
+        let label = Array.isArray(value) ? value.join(', ') : value;  // Default to the value itself
+        if (attribute?.options) {
+            const option = attribute.options.find(opt => opt.value === value);
+            if (option) {
+                label = option.label;
+            }
+        }
         const newMapping = {
             ...mappings[shopifyAttr],
+            value: label,
             mappedValue: value
         };
 

--- a/src/components/AttributeMapping.tsx
+++ b/src/components/AttributeMapping.tsx
@@ -17,6 +17,10 @@ interface AttributeMappingProps {
     hideButtons?: boolean;
     excludeAttributes?: string[];
 }
+interface Option {
+    label: string;
+    value: string;
+}
 
 interface ValidationResult {
     isValid: boolean;
@@ -215,6 +219,7 @@ const AttributeMapping: React.FC<AttributeMappingProps> = ({
     excludeAttributes = []
 }) => {
     const [mappings, setMappings] = useState<AttributeMappingType>({});
+    const [orignalMappings, setOrignalMappings] = useState<AttributeMappingType>({});
     const [touched, setTouched] = useState<{ [key: string]: boolean }>({});
 
 
@@ -303,6 +308,8 @@ const AttributeMapping: React.FC<AttributeMappingProps> = ({
         });
 
         setMappings(initialMappings);
+        // keep a copy of the original mappings to compare with later
+        setOrignalMappings(initialMappings);
 
         // Initialize touched state for all attributes
         const initialTouched: { [key: string]: boolean } = {};
@@ -315,7 +322,7 @@ const AttributeMapping: React.FC<AttributeMappingProps> = ({
         if (hideButtons) {
             onSave(initialMappings);
         }
-    }, [product, variant, attributes]);
+    }, [product, variant]);
 
     const handleAttributeChange = (shopifyAttr: string, magentoAttr: string,) => {
         const attribute = attributes.find(attr => attr.attribute_code === magentoAttr);
@@ -354,11 +361,17 @@ const AttributeMapping: React.FC<AttributeMappingProps> = ({
 
     };
 
-    const handleValueChange = (shopifyAttr: string, value: string | string[]) => {
-
+    const handleValueChange = (shopifyAttr: string, value: string | string[], newOptions?: Option[]) => {
         // Get the selected attribute
         const attributeCode = mappings[shopifyAttr].mappedTo;
-        const attribute = attributes.find(attr => attr.attribute_code === attributeCode);
+        let attribute: MagentoAttributeMetadata | undefined
+
+        if (newOptions) {
+            const updatedAttribute = handleOptionsUpdate(attributeCode, newOptions)
+            attribute = updatedAttribute.find(attr => attr.attribute_code === attributeCode);
+        } else {
+            attribute = attributes.find(attr => attr.attribute_code === attributeCode);
+        }
 
         // Find the label for the selected value from Magento options
         let label = Array.isArray(value) ? value.join(', ') : value;  // Default to the value itself
@@ -398,7 +411,7 @@ const AttributeMapping: React.FC<AttributeMappingProps> = ({
         return attribute?.options || [];
     };
 
-    const handleOptionsUpdate = (attributeCode: string, newOptions: Array<{ label: string; value: string }>) => {
+    const handleOptionsUpdate = (attributeCode: string, newOptions: Array<{ label: string; value: string }>): MagentoAttributeMetadata[] => {
         // Find and update the attribute in the attributes array
         const updatedAttributes = attributes.map(attr => {
             if (attr.attribute_code === attributeCode) {
@@ -416,6 +429,7 @@ const AttributeMapping: React.FC<AttributeMappingProps> = ({
         // Update the attributes state in the parent component
         // You'll need to add this prop to the AttributeMapping component
         onAttributesUpdate(updatedAttributes);
+        return updatedAttributes;
     };
 
     return (
@@ -447,7 +461,7 @@ const AttributeMapping: React.FC<AttributeMappingProps> = ({
                         selectedMagentoAttr?.frontend_input === 'multiselect';
 
                     const validation = validateAttributeMapping(
-                        mapping.value,
+                        orignalMappings[shopifyAttr]?.value || mapping.value,
                         mapping.mappedValue,
                         isSelect ? getAttributeOptions(mapping.mappedTo) : undefined
                     );
@@ -463,7 +477,7 @@ const AttributeMapping: React.FC<AttributeMappingProps> = ({
                                         {shopifyAttr}:
                                     </span>
                                     <span className="text-sm text-gray-600">
-                                        {mapping.value}
+                                        {orignalMappings[shopifyAttr]?.value || mapping.value}
                                     </span>
                                     {validationState === 'warning' && (
                                         <span className="ml-2 text-xs text-yellow-600">
@@ -491,9 +505,7 @@ const AttributeMapping: React.FC<AttributeMappingProps> = ({
                                                         value: opt.value
                                                     }))}
                                                     value={mapping.mappedValue as string}
-                                                    onChange={(value: string) => handleValueChange(shopifyAttr, value)}
-                                                    onOptionsChange={(newOptions) => handleOptionsUpdate(mapping.mappedTo, newOptions)}
-                                                    placeholder="Select Value"
+                                                    onChange={(value: string, label: string, newOptions?: Option[]) => handleValueChange(shopifyAttr, value, newOptions)} placeholder="Select Value"
                                                     attributeCode={mapping.mappedTo}
                                                     allowCreate={true}
                                                 />

--- a/src/components/MultiVariantMapping.tsx
+++ b/src/components/MultiVariantMapping.tsx
@@ -385,6 +385,10 @@ const MultiVariantMapping: React.FC<MultiVariantMappingProps> = ({
 
     // Update variant mapping but exclude product-level attributes
     const handleVariantMapping = (index: number, mappings: AttributeMappingType) => {
+
+        // Find the actual index in the full variantMappings array
+        const variantSku = filteredVariantMappings[index].variant.sku;
+        const fullArrayIndex = variantMappings.findIndex(m => m.variant.sku === variantSku);
         // Keep variant-specific mappings but ensure latest product attributes are included
         const combinedMappings = {
             ...mappings, // Variant-specific mappings
@@ -393,7 +397,7 @@ const MultiVariantMapping: React.FC<MultiVariantMappingProps> = ({
             description: productAttributes.description,
             category_ids: productAttributes.category_ids
         };
-        onUpdateMapping(index, combinedMappings);
+        onUpdateMapping(fullArrayIndex, combinedMappings);
     };
 
 

--- a/src/components/SearchableSelect.tsx
+++ b/src/components/SearchableSelect.tsx
@@ -120,11 +120,16 @@ const SearchableSelect: React.FC<SearchableSelectProps> = ({
                 onOptionsChange(updatedOptions);
             }
 
+            const newValue = data.option.value;
+
+            setTimeout(() => {
+                setIsOpen(false);
+                setSearchTerm("");
+                setIsCreating(false);
+            }, 100);
+
             // Call onChange with the new value
-            onChange(data.option.value, searchTerm.trim());
-            setIsOpen(false);
-            setSearchTerm("");
-            setIsCreating(false);
+            onChange(newValue, searchTerm.trim());
 
         } catch (error) {
             setCreateError((error as Error).message);


### PR DESCRIPTION
- The use effect for setting inital mapping gets triggered when attributes updates. remove the attributes dependency for that useeffect.
- Keep original mapping for validation. 